### PR TITLE
Changed getLogs to recursively call Etherscan until all tx are fetched

### DIFF
--- a/src/components/Markets/Markets.js
+++ b/src/components/Markets/Markets.js
@@ -180,7 +180,7 @@ class Markets extends React.Component {
 
 
   componentWillMount() {
-    AirSwap.getLogs(0)
+    AirSwap.getLogs()
       .then(x => {
         this.evalAirSwapDEXFilledEventLogs(x);
         // this.handleToken1Selected(data[0]);


### PR DESCRIPTION
regarding issue #19, this should fix it
+ when >1000 tx are found in block range, Etherscan is called recursively until all are obtained
+ returns cached version if called multiple times within 60s now.
+ when data is already loaded, he starts loading from the latest point that was already fetched