### PR TITLE
Optimize getTokenByName & getTokenByAddress

### DIFF
--- a/src/services/Tokens/Tokens.js
+++ b/src/services/Tokens/Tokens.js
@@ -281,8 +281,26 @@ const EthereumTokens = [
     },
 ]
 
+let EthereumTokensSN = EthereumTokens.sort((a, b) => {
+    return a.name.localeCompare(b.name);
+});
+
 var getTokenByName = (name) => {
-    return EthereumTokens.find(token => token.name === name);
+    let l = 0;
+    let h = EthereumTokensSN.length - 1;
+    while(l <= h) {
+        let m = Math.floor((l + h) / 2);
+        let mName = EthereumTokensSN[m].name;
+        let c = name.toLocaleLowerCase().localeCompare(mName.toLocaleLowerCase());
+        if(c == 0) {
+            return EthereumTokensSN[m];
+        } else if(c > 0) {
+            l = m + 1;
+        } else {
+            h = m - 1;
+        }
+    }
+    return undefined;
 }
 
 var getTokenByAddress = (address) => {

--- a/src/services/Tokens/Tokens.js
+++ b/src/services/Tokens/Tokens.js
@@ -303,8 +303,26 @@ var getTokenByName = (name) => {
     return undefined;
 }
 
+let EthereumTokensSA = EthereumTokens.sort((a, b) => {
+    return a.address.localeCompare(b.address);
+});
+
 var getTokenByAddress = (address) => {
-    return EthereumTokens.find(token => token.address === address);
+    let l = 0;
+    let h = EthereumTokensSA.length - 1;
+    while(l <= h) {
+        let m = Math.floor((l + h) / 2);
+        let mAddr = EthereumTokensSA[m].address;
+        let c = address.toLocaleLowerCase().localeCompare(mAddr.toLocaleLowerCase());
+        if(c == 0) {
+            return EthereumTokensSA[m];
+        } else if(c > 0) {
+            l = m + 1;
+        } else {
+            h = m - 1;
+        }
+    }
+    return undefined;
 }
 
 module.exports.EthereumTokens = {


### PR DESCRIPTION
Use Binary Search to reduce the complexity of getTokenByName & getTokenByAddress to O(log N)